### PR TITLE
Allow users to set their own npm-like executables such as `yarn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Dual-licensed under `MIT` or the [UNLICENSE](http://unlicense.org/).
 - Serve static resources as directory in `actix-web`
 - Install dependencies with [npm](https://npmjs.org) package manager
 - Run custom `npm` run commands (such as [webpack](https://webpack.js.org/))
+- Support for npm-like package managers ([yarn](https://yarnpkg.com/))
 
 ## Usage
 
@@ -239,7 +240,6 @@ use actix_web_static_files::NpmBuild;
 
 fn main() {
     NpmBuild::new("./web")
-        .executable("yarn")
         .install().unwrap()
         .run("build").unwrap()
         .target("./web/dist")
@@ -307,4 +307,22 @@ $ curl -v http://localhost:8080
   </head>
   <body>
   <script type="text/javascript" src="main.js"></script></body>
+```
+
+### Use-case #4: yarn package manager
+
+We can use another package manager instead of `npm`. For example, to use [yarn](https://yarnpkg.com/) just add `.executable("yarn")` to `NpmBuild` call:
+
+```rust
+use actix_web_static_files::NpmBuild;
+
+fn main() {
+    NpmBuild::new("./web")
+        .executable("yarn")
+        .install().unwrap()
+        .run("build").unwrap()
+        .target("./web/dist")
+        .to_resource_dir()
+        .build().unwrap();
+}
 ```

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ use actix_web_static_files::NpmBuild;
 
 fn main() {
     NpmBuild::new("./web")
+        .executable("yarn")
         .install().unwrap()
         .run("build").unwrap()
         .target("./web/dist")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,7 @@ use actix_web_static_files::NpmBuild;
 
 fn main() {
     NpmBuild::new("./web")
+        .executable("yarn")
         .install().unwrap()
         .run("build").unwrap()
         .target("./web/dist")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ Dual-licensed under `MIT` or the [UNLICENSE](http://unlicense.org/).
 - Serve static resources as directory in `actix-web`
 - Install dependencies with [npm](https://npmjs.org) package manager
 - Run custom `npm` run commands (such as [webpack](https://webpack.js.org/))
+- Support for npm-like package managers ([yarn](https://yarnpkg.com/))
 
 ## Usage
 
@@ -241,7 +242,6 @@ use actix_web_static_files::NpmBuild;
 
 fn main() {
     NpmBuild::new("./web")
-        .executable("yarn")
         .install().unwrap()
         .run("build").unwrap()
         .target("./web/dist")
@@ -309,6 +309,24 @@ $ curl -v http://localhost:8080
   </head>
   <body>
   <script type="text/javascript" src="main.js"></script></body>
+```
+
+### Use-case #4: yarn package manager
+
+We can use another package manager instead of `npm`. For example, to use [yarn](https://yarnpkg.com/) just add `.executable("yarn")` to `NpmBuild` call:
+
+```rust#ignore
+use actix_web_static_files::NpmBuild;
+
+fn main() {
+    NpmBuild::new("./web")
+        .executable("yarn")
+        .install().unwrap()
+        .run("build").unwrap()
+        .target("./web/dist")
+        .to_resource_dir()
+        .build().unwrap();
+}
 ```
 
 */


### PR DESCRIPTION
Due to the many inefficiencies of npm, a lot of projects out there prefer to use other package managers such as `yarn`. This adds a builder option that allows you to set your preferred executable to invoke (assuming it responds to the standard npm-like commands)

Some fun hyperfine benchmarks I ran on a personal project:
```
Benchmark #1: cargo build (using npm)                                                                                                                                                                                
Time (mean ± σ):     29.870 s ±  0.193 s    [User: 33.465 s, System: 6.722 s]                                                                                                                                        
Range (min … max):   29.541 s … 30.207 s    10 runs                                                                                                                                                                  
                                                                                                                                                                                                                     
Benchmark #1: cargo build (using yarn)                                                                                                                                                                               
  Time (mean ± σ):     16.283 s ±  0.125 s    [User: 18.931 s, System: 5.503 s]                                                                                                                                      
  Range (min … max):   15.941 s … 16.369 s    10 runs
```