### PR TITLE
migrate away from deprecated failure crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ version = "3.0.1"
 [dependencies]
 actix-web = { version = "3.0", default-features = false }
 actix-service = { version = "1.0.6", default-features = false }
+derive_more = "0.99.5"
 futures = { version = "0.3", default-features = false }
 mime_guess = "2.0"
 failure = { version = "0.1", default-features = false, features = ["derive"] }
@@ -27,6 +28,7 @@ path-slash = "0.1"
 [build-dependencies]
 actix-web = { version = "3.0", default-features = false }
 actix-service = { version = "1.0.6", default-features = false }
+derive_more = "0.99.5"
 futures = { version = "0.3", default-features = false }
 mime_guess = "2.0"
 failure = { version = "0.1", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ version = "3.0.1"
 
 [dependencies]
 actix-web = { version = "3.0", default-features = false }
-actix-service = { version = "1.0", default-features = false }
+actix-service = { version = "1.0.6", default-features = false }
 futures = { version = "0.3", default-features = false }
 mime_guess = "2.0"
 failure = { version = "0.1", default-features = false, features = ["derive"] }
@@ -26,7 +26,7 @@ path-slash = "0.1"
 
 [build-dependencies]
 actix-web = { version = "3.0", default-features = false }
-actix-service = { version = "1.0", default-features = false }
+actix-service = { version = "1.0.6", default-features = false }
 futures = { version = "0.3", default-features = false }
 mime_guess = "2.0"
 failure = { version = "0.1", default-features = false, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ actix-service = { version = "1.0.6", default-features = false }
 derive_more = "0.99.5"
 futures = { version = "0.3", default-features = false }
 mime_guess = "2.0"
-failure = { version = "0.1", default-features = false, features = ["derive"] }
 path-slash = "0.1"
 
 [build-dependencies]
@@ -31,5 +30,4 @@ actix-service = { version = "1.0.6", default-features = false }
 derive_more = "0.99.5"
 futures = { version = "0.3", default-features = false }
 mime_guess = "2.0"
-failure = { version = "0.1", default-features = false, features = ["derive"] }
 path-slash = "0.1"

--- a/src/impl.rs
+++ b/src/impl.rs
@@ -6,7 +6,6 @@ use actix_web::{
     HttpMessage, HttpRequest, HttpResponse, ResponseError,
 };
 use derive_more::{Display, Error};
-use failure::Fail;
 use futures::future::{ok, FutureExt, LocalBoxFuture, Ready};
 use path_slash::PathExt;
 use std::{
@@ -253,19 +252,6 @@ fn none_match(etag: Option<&header::EntityTag>, req: &HttpRequest) -> bool {
     }
 }
 
-#[derive(Fail, Debug, PartialEq)]
-enum OldUriSegmentError {
-    /// The segment started with the wrapped invalid character.
-    #[fail(display = "The segment started with the wrapped invalid character")]
-    BadStart(char),
-    /// The segment contained the wrapped invalid character.
-    #[fail(display = "The segment contained the wrapped invalid character")]
-    BadChar(char),
-    /// The segment ended with the wrapped invalid character.
-    #[fail(display = "The segment ended with the wrapped invalid character")]
-    BadEnd(char),
-}
-
 #[derive(Debug, PartialEq, Display, Error)]
 pub enum UriSegmentError {
     /// The segment started with the wrapped invalid character.
@@ -290,7 +276,6 @@ mod tests_error_impl {
     #[test]
     fn test_error_impl() {
         // ensure backwards compatibility when migrating away from failure
-        assert_send_and_sync::<OldUriSegmentError>();
         assert_send_and_sync::<UriSegmentError>();
     }
 }

--- a/src/impl.rs
+++ b/src/impl.rs
@@ -5,6 +5,7 @@ use actix_web::{
     http::{header, Method, StatusCode},
     HttpMessage, HttpRequest, HttpResponse, ResponseError,
 };
+use derive_more::{Display, Error};
 use failure::Fail;
 use futures::future::{ok, FutureExt, LocalBoxFuture, Ready};
 use path_slash::PathExt;
@@ -199,10 +200,11 @@ fn respond_to(req: &HttpRequest, item: Option<&Resource>) -> HttpResponse {
         let not_modified = !none_match(etag.as_ref(), req);
 
         let mut resp = HttpResponse::build(StatusCode::OK);
-        resp.set_header(header::CONTENT_TYPE, file.mime_type)
-            .if_some(etag, |etag, resp| {
-                resp.set(header::ETag(etag));
-            });
+        resp.set_header(header::CONTENT_TYPE, file.mime_type);
+
+        if let Some(etag) = etag {
+            resp.set(header::ETag(etag));
+        }
 
         if precondition_failed {
             return resp.status(StatusCode::PRECONDITION_FAILED).finish();
@@ -252,7 +254,7 @@ fn none_match(etag: Option<&header::EntityTag>, req: &HttpRequest) -> bool {
 }
 
 #[derive(Fail, Debug, PartialEq)]
-pub enum UriSegmentError {
+enum OldUriSegmentError {
     /// The segment started with the wrapped invalid character.
     #[fail(display = "The segment started with the wrapped invalid character")]
     BadStart(char),
@@ -262,6 +264,35 @@ pub enum UriSegmentError {
     /// The segment ended with the wrapped invalid character.
     #[fail(display = "The segment ended with the wrapped invalid character")]
     BadEnd(char),
+}
+
+#[derive(Debug, PartialEq, Display, Error)]
+pub enum UriSegmentError {
+    /// The segment started with the wrapped invalid character.
+    #[display(fmt = "The segment started with the wrapped invalid character")]
+    BadStart(#[error(not(source))] char),
+
+    /// The segment contained the wrapped invalid character.
+    #[display(fmt = "The segment contained the wrapped invalid character")]
+    BadChar(#[error(not(source))] char),
+
+    /// The segment ended with the wrapped invalid character.
+    #[display(fmt = "The segment ended with the wrapped invalid character")]
+    BadEnd(#[error(not(source))] char),
+}
+
+#[cfg(test)]
+mod tests_error_impl {
+    use super::*;
+
+    fn assert_send_and_sync<T: Send + Sync + 'static>() {}
+
+    #[test]
+    fn test_error_impl() {
+        // ensure backwards compatibility when migrating away from failure
+        assert_send_and_sync::<OldUriSegmentError>();
+        assert_send_and_sync::<UriSegmentError>();
+    }
 }
 
 /// Return `BadRequest` for `UriSegmentError`


### PR DESCRIPTION
also bumps actix-service dep to 1.0.6

see https://deps.rs/crate/actix-web-static-files/3.0.1

Backwards compatible since failure provides a blanket impl for all std errors that are send + sync which is proven to be the case in an added test.