### PR TITLE
add #[must_use] to generate function

### DIFF
--- a/src/impl.rs
+++ b/src/impl.rs
@@ -484,7 +484,7 @@ pub fn generate_resources<P: AsRef<Path>, G: AsRef<Path>>(
 
     writeln!(
         f,
-        "#[allow(clippy::unreadable_literal)] pub fn {}() -> ::std::collections::HashMap<&'static str, ::actix_web_static_files::Resource> {{
+        "#[allow(clippy::unreadable_literal)] #[must_use] pub fn {}() -> ::std::collections::HashMap<&'static str, ::actix_web_static_files::Resource> {{
 use ::actix_web_static_files::new_resource as n;
 use ::std::include_bytes as i;
 let mut r = ::std::collections::HashMap::new();",


### PR DESCRIPTION
The clippy lint https://rust-lang.github.io/rust-clippy/master/index.html#must_use_candidate suggest that this function should have a must use flag - it does seem sensible to me. - but please verify this does not break anything.