### PR TITLE
#54 Add `do_use_guard` option

### DIFF
--- a/src/resource_files.rs
+++ b/src/resource_files.rs
@@ -109,7 +109,7 @@ impl Deref for ResourceFiles {
 impl Guard for ResourceFiles {
     fn check(&self, ctx: &GuardContext<'_>) -> bool {
         for filename in self.inner.files.keys() {
-            if *filename == ctx.head().uri.path() {
+            if format!("/{}", filename) == ctx.head().uri.path() {
                 return true;
             }
         }


### PR DESCRIPTION
Adds the `do_use_guard` option, which when enabled, only calls the handler function when the files actually match. This allows people to use a static file handler on root, or other paths that also have other 'catch all' handlers that are probably slower than a hashmap check. This is useful because some static files need to be hosted on the root path, such as `/robots.txt`.

closes #54